### PR TITLE
Fix -Wreorder warnings.

### DIFF
--- a/tl/expected.hpp
+++ b/tl/expected.hpp
@@ -325,11 +325,11 @@ struct expected_storage_base {
       m_unexpect.~unexpected<E>();
     }
   }
-  bool m_has_val;
   union {
     T m_val;
     unexpected<E> m_unexpect;
   };
+  bool m_has_val;
 };
 
 // This specialization is for when both `T` and `E` are trivially-destructible,
@@ -365,11 +365,11 @@ template <class T, class E> struct expected_storage_base<T, E, true, true> {
       : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
 
   ~expected_storage_base() = default;
-  bool m_has_val;
   union {
     T m_val;
     unexpected<E> m_unexpect;
   };
+  bool m_has_val;
 };
 
 // T is trivial, E is not.
@@ -409,11 +409,11 @@ template <class T, class E> struct expected_storage_base<T, E, true, false> {
     }
   }
 
-  bool m_has_val;
   union {
     T m_val;
     unexpected<E> m_unexpect;
   };
+  bool m_has_val;
 };
 
 // E is trivial, T is not.
@@ -452,11 +452,11 @@ template <class T, class E> struct expected_storage_base<T, E, false, true> {
       m_val.~T();
     }
   }
-  bool m_has_val;
   union {
     T m_val;
     unexpected<E> m_unexpect;
   };
+  bool m_has_val;
 };
 
 // `T` is `void`, `E` is trivially-destructible
@@ -481,12 +481,12 @@ template <class E> struct expected_storage_base<void, E, false, true> {
       : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
 
   ~expected_storage_base() = default;
-  bool m_has_val;
   struct dummy {};
   union {
     dummy m_val;
     unexpected<E> m_unexpect;
   };
+  bool m_has_val;
 };
 
 // `T` is `void`, `E` is not trivially-destructible
@@ -516,12 +516,12 @@ template <class E> struct expected_storage_base<void, E, false, false> {
     }
   }
 
-  bool m_has_val;
   struct dummy {};
   union {
     dummy m_val;
     unexpected<E> m_unexpect;
   };
+  bool m_has_val;
 };
 
 // This base class provides some handy member functions which can be used in


### PR DESCRIPTION
Fix warnings like the following:

```
./tl/expected.hpp:396:9: warning: field 'm_unexpect' will be initialized after
      field 'm_has_val' [-Wreorder]
      : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
        ^
./tl/expected.hpp:1397:9: note: in instantiation of function template
      specialization 'tl::detail::expected_storage_base<int,
      std::__1::basic_string<char>, true,
      false>::expected_storage_base<std::__1::basic_string<char> , nullptr>'
      requested here
      : impl_base(unexpect, std::move(e.value())),
        ^
test.cpp:8:16: note: in instantiation of function template specialization
      'tl::expected<int, std::__1::basic_string<char>
      >::expected<std::__1::basic_string<char>, nullptr, nullptr>' requested
      here
        …

In file included from test.cpp:3:
./tl/expected.hpp:384:9: warning: field 'm_val' will be initialized after field
      'm_has_val' [-Wreorder]
      : m_val(std::forward<Args>(args)...), m_has_val(true) {}
        ^
./tl/expected.hpp:1348:9: note: in instantiation of function template
      specialization 'tl::detail::expected_storage_base<int,
      std::__1::basic_string<char>, true, false>::expected_storage_base<int,
      nullptr>' requested here
      : impl_base(in_place, std::forward<Args>(args)...),
        ^
./tl/expected.hpp:1487:52: note: in instantiation of function template
      specialization 'tl::expected<int, std::__1::basic_string<char>
      >::expected<int, nullptr>' requested here
  TL_EXPECTED_MSVC2015_CONSTEXPR expected(U &&v) : expected(in_place, st...
                                                   ^
test.cpp:9:12: note: in instantiation of function template specialization
      'tl::expected<int, std::__1::basic_string<char> >::expected<int, nullptr,
      nullptr>' requested here
    …
```

(In C++, declaration order determines the initialization order.)