### PR TITLE
Fix unused-parameter warning when exceptions are disabled

### DIFF
--- a/tl/expected.hpp
+++ b/tl/expected.hpp
@@ -224,6 +224,7 @@ template<typename E>
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
     throw std::forward<E>(e);
 #else
+  (void)e;
   #ifdef _MSC_VER
     __assume(0);
   #else


### PR DESCRIPTION
If `TL_EXPECTED_EXCEPTIONS_ENABLED` is not defined, gcc produces an unused parameter warning on `e`