### PR TITLE
Add Conan package manifest

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,34 @@
+from conans import ConanFile, CMake, tools
+
+class ExpectedConan(ConanFile):
+    name = "expected"
+    version = "master"
+    license = "CC0-1.0"
+    author = "Simon Brand <tartanllama@gmail.com>"
+    url = "https://github.com/TartanLlama/expected"
+    description = "C++11/14/17 std::expected with functional-style extensions"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    exports_sources = "*"
+
+    def source(self):
+        tools.replace_in_file('CMakeLists.txt', 'project(expected)',
+        '''project(expected)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+        ''')
+
+    def configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self.configure_cmake()
+        cmake.build()
+       
+        if not tools.cross_building(self.settings):
+            self.run('%s/bin/tests' % self.build_folder)
+
+    def package(self):
+        self.copy('*.hpp', dst='include/tl', src='tl')

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class ExpectedTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")
+        self.copy('*.so*', dst='bin', src='lib')
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,0 +1,15 @@
+#include <tl/expected.hpp>
+
+tl::expected<int, const char*> maybe_do_something(int i) {
+  if (i < 5) {
+    return 0;
+  } else {
+    return tl::make_unexpected("Uh oh");
+  }
+}
+
+int main(int argc, char** argv) {
+  (void)argv;
+
+  return maybe_do_something(0).value_or(-1);
+}


### PR DESCRIPTION
This PR defines a Conan package for `expected` and a test package that can be used by `conan create` to verify the package's exported paths.

Although it is convenient to include `expected` in a project just by copying in a header file, a Conan package is useful when using `expected` in multiple related projects, i.e. so that `expected` is included only once.

The Conan package places `expected.hpp` under `include/tl`.

It neither generates nor includes documentation, though it would be possible to add that if so desired.