### PR TITLE
Move the error value when throwing an exception in .value rval overloads

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -1907,14 +1907,14 @@ public:
             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
   TL_EXPECTED_11_CONSTEXPR const U &&value() const && {
     if (!has_value())
-      detail::throw_exception(bad_expected_access<E>(err().value()));
+      detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
     return std::move(val());
   }
   template <class U = T,
             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
   TL_EXPECTED_11_CONSTEXPR U &&value() && {
     if (!has_value())
-      detail::throw_exception(bad_expected_access<E>(err().value()));
+      detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
     return std::move(val());
   }
 

--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -18,7 +18,7 @@
 
 #define TL_EXPECTED_VERSION_MAJOR 1
 #define TL_EXPECTED_VERSION_MINOR 0
-#define TL_EXPECTED_VERSION_PATCH 0
+#define TL_EXPECTED_VERSION_PATCH 1
 
 #include <exception>
 #include <functional>

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -127,3 +127,12 @@ TEST_CASE("Issue 49", "[issues.49]") {
     .and_then(test2);
 }
 #endif
+
+tl::expected<int, std::unique_ptr<std::string>> func()
+{
+  return 1;
+}
+
+TEST_CASE("Issue 61", "[issues.61]") {
+  REQUIRE(func().value() == 1);
+}


### PR DESCRIPTION
Fixes #61