### PR TITLE
[update]: CMake git_repository to URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option(EXPECTED_ENABLE_TESTS "Enable tests." ON)
 include(FetchContent)
 FetchContent_Declare(
   tl_cmake
-  GIT_REPOSITORY https://github.com/TartanLlama/tl-cmake.git
+  URL https://github.com/TartanLlama/tl-cmake/archive/master.zip
 )
 FetchContent_GetProperties(tl_cmake)
 if(NOT tl_cmake_POPULATED)


### PR DESCRIPTION
For the convenience of tools such as `travis` `lgtm`

using zip instead of git repository to solve error:
<img width="1164" alt="Capture d’écran 2019-09-12 à 10 59 37" src="https://user-images.githubusercontent.com/21139416/64769921-79d8e880-d54c-11e9-8c71-d5dd74ff2c05.png">

LGTM related issue: https://discuss.lgtm.com/t/update-cmake-to-3-14-to-allow-fetch-content/2048/12?u=milerius

ps: you was mixing file ending on this file between CRLF and LF, github web editor automatically put it as CRLF