### PR TITLE
Fix unused-parameter warning when exceptions are disabled

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -188,6 +188,7 @@ template<typename E>
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
     throw std::forward<E>(e);
 #else
+    (void)e;
   #ifdef _MSC_VER
     __assume(0);
   #else


### PR DESCRIPTION
This is the same issue as fixed in #48, but it was reintroduced by 3674ba52957d8db681cd3f8498393c897b401615

closes #71