### PR TITLE
Add support for building on Apple silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(EXPECTED_BUILD_TESTS)
   set(CATCH_BUILD_TESTING OFF)
   set(CATCH_INSTALL_DOCS OFF)
   FetchContent_Declare(Catch2 URL
-    https://github.com/catchorg/Catch2/archive/v2.9.2.zip) 
+    https://github.com/catchorg/Catch2/archive/v2.13.6.zip)
   FetchContent_MakeAvailable(Catch2)
 
   file(GLOB test-sources CONFIGURE_DEPENDS tests/*.cpp)


### PR DESCRIPTION
Updating to the latest Catch2 will allow `expected` to also compile for Apple silicon natively.

Once updated

% mkdir build
% cd build
% cmake ..
% make
% make test
Running tests...
Test project /Users/test/expected/build
    Start 1: tl::expected::tests
1/1 Test #1: tl::expected::tests ..............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.01 sec