### PR TITLE
Add SPDX license header

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -11,6 +11,9 @@
 // You should have received a copy of the CC0 Public Domain Dedication
 // along with this software. If not, see
 // <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+// SPDX-License-Identifier: CC-PDDC
+// SPDX-FileCopyrightText: None
 ///
 
 #ifndef TL_EXPECTED_HPP


### PR DESCRIPTION
This is used by tools like 'reuse lint' to help managing license compliance.

CC-PDDC refers to https://spdx.org/licenses/CC-PDDC.html

Other options in the spirit of this text would be https://spdx.org/licenses/Unlicense.html or https://spdx.org/licenses/CC0-1.0.html