### PR TITLE
Fix warnings in test

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -807,7 +807,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
       if (rhs.m_has_val) {
         get() = std::forward<Rhs>(rhs).get();
       } else {
-		destroy_val();
+        destroy_val();
         construct_error(std::forward<Rhs>(rhs).geterr());
       }
     } else {
@@ -840,7 +840,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
 #endif
 
   TL_EXPECTED_11_CONSTEXPR void destroy_val() {
-	get().~T();
+    get().~T();
   }
 };
 
@@ -895,7 +895,7 @@ struct expected_operations_base<void, E> : expected_storage_base<void, E> {
 #endif
 
   TL_EXPECTED_11_CONSTEXPR void destroy_val() {
-	  //no-op
+    //no-op
   }
 };
 

--- a/tests/bases.cpp
+++ b/tests/bases.cpp
@@ -38,9 +38,9 @@ TEST_CASE("Triviality", "[bases.triviality]") {
     {
         struct T {
             T(const T&){}
-            T(T&&) {};
+            T(T&&) {}
             T& operator=(const T&) {}
-            T& operator=(T&&) {};
+            T& operator=(T&&) {}
             ~T(){}
         };
         REQUIRE(!std::is_trivially_copy_constructible<tl::expected<T,int>>::value);

--- a/tests/bases.cpp
+++ b/tests/bases.cpp
@@ -39,8 +39,8 @@ TEST_CASE("Triviality", "[bases.triviality]") {
         struct T {
             T(const T&){}
             T(T&&) {}
-            T& operator=(const T&) {}
-            T& operator=(T&&) {}
+            T& operator=(const T&) { return *this; }
+            T& operator=(T&&) { return *this; }
             ~T(){}
         };
         REQUIRE(!std::is_trivially_copy_constructible<tl::expected<T,int>>::value);

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -3,6 +3,7 @@
 
 #define TOKENPASTE(x, y) x##y
 #define TOKENPASTE2(x, y) TOKENPASTE(x, y)
+#undef STATIC_REQUIRE
 #define STATIC_REQUIRE(e)                                                      \
   constexpr bool TOKENPASTE2(rqure, __LINE__) = e;                             \
   (void)TOKENPASTE2(rqure, __LINE__);                                          \

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE("Map extensions", "[extensions.map]") {
   auto mul2 = [](int a) { return a * 2; };
-  auto ret_void = [](int a) {};
+  auto ret_void = [](int a) { (void)a; };
 
   {
     tl::expected<int, int> e = 21;
@@ -143,7 +143,7 @@ TEST_CASE("Map extensions", "[extensions.map]") {
 
 TEST_CASE("Map error extensions", "[extensions.map_error]") {
   auto mul2 = [](int a) { return a * 2; };
-  auto ret_void = [](int a) {};
+  auto ret_void = [](int a) { (void)a; };
 
   {
     tl::expected<int, int> e = 21;
@@ -252,8 +252,8 @@ TEST_CASE("Map error extensions", "[extensions.map_error]") {
 }
 
 TEST_CASE("And then extensions", "[extensions.and_then]") {
-  auto succeed = [](int a) { return tl::expected<int, int>(21 * 2); };
-  auto fail = [](int a) { return tl::expected<int, int>(tl::unexpect, 17); };
+  auto succeed = [](int a) { (void)a; return tl::expected<int, int>(21 * 2); };
+  auto fail = [](int a) { (void)a; return tl::expected<int, int>(tl::unexpect, 17); };
 
   {
     tl::expected<int, int> e = 21;
@@ -370,9 +370,9 @@ TEST_CASE("And then extensions", "[extensions.and_then]") {
 
 TEST_CASE("or_else", "[extensions.or_else]") {
   using eptr = std::unique_ptr<int>;
-  auto succeed = [](int a) { return tl::expected<int, int>(21 * 2); };
-  auto succeedptr = [](eptr e) { return tl::expected<int,eptr>(21*2);};
-  auto fail =    [](int a) { return tl::expected<int,int>(tl::unexpect, 17);};
+  auto succeed = [](int a) { (void)a; return tl::expected<int, int>(21 * 2); };
+  auto succeedptr = [](eptr e) { (void)e; return tl::expected<int,eptr>(21*2);};
+  auto fail =    [](int a) { (void)a; return tl::expected<int,int>(tl::unexpect, 17);};
   auto efail =   [](eptr e) { *e = 17;return tl::expected<int,eptr>(tl::unexpect, std::move(e));};
   auto failptr = [](eptr e) { return tl::expected<int,eptr>(tl::unexpect, std::move(e));};
   auto failvoid = [](int) {};
@@ -569,7 +569,7 @@ TEST_CASE("14", "[issue.14]") {
     auto res = tl::expected<S,F>{tl::unexpect, F{}};
 
     res.map_error([](F f) {
-
+        (void)f;
     });
 }
 

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -5,6 +5,7 @@
 #define TOKENPASTE2(x, y) TOKENPASTE(x, y)
 #define STATIC_REQUIRE(e)                                                      \
   constexpr bool TOKENPASTE2(rqure, __LINE__) = e;                             \
+  (void)TOKENPASTE2(rqure, __LINE__);                                          \
   REQUIRE(e);
 
 TEST_CASE("Map extensions", "[extensions.map]") {

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -373,8 +373,7 @@ TEST_CASE("or_else", "[extensions.or_else]") {
   auto succeed = [](int a) { (void)a; return tl::expected<int, int>(21 * 2); };
   auto succeedptr = [](eptr e) { (void)e; return tl::expected<int,eptr>(21*2);};
   auto fail =    [](int a) { (void)a; return tl::expected<int,int>(tl::unexpect, 17);};
-  auto efail =   [](eptr e) { *e = 17;return tl::expected<int,eptr>(tl::unexpect, std::move(e));};
-  auto failptr = [](eptr e) { return tl::expected<int,eptr>(tl::unexpect, std::move(e));};
+  auto failptr = [](eptr e) { *e = 17;return tl::expected<int,eptr>(tl::unexpect, std::move(e));};
   auto failvoid = [](int) {};
   auto failvoidptr = [](const eptr&) { /* don't consume */};
   auto consumeptr = [](eptr) {};
@@ -439,7 +438,7 @@ TEST_CASE("or_else", "[extensions.or_else]") {
 
   {
     tl::expected<int, eptr> e = 21;
-    auto ret = std::move(e).or_else(efail);
+    auto ret = std::move(e).or_else(failptr);
     REQUIRE(ret);
     REQUIRE(ret == 21);
   }

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Issue 1", "[issues.1]") { getInt1(); }
 
 tl::expected<int, int> operation1() { return 42; }
 
-tl::expected<std::string, int> operation2(int const val) { return "Bananas"; }
+tl::expected<std::string, int> operation2(int const val) { (void)val; return "Bananas"; }
 
 TEST_CASE("Issue 17", "[issues.17]") {
   auto const intermediate_result = operation1();
@@ -67,7 +67,7 @@ struct i31{
 };
 TEST_CASE("Issue 31", "[issues.31]") {
     const tl::expected<i31, int> a = i31{42};
-    a->i;
+    (void)a->i;
 
     tl::expected< void, std::string > result;
     tl::expected< void, std::string > result2 = result;
@@ -77,7 +77,7 @@ TEST_CASE("Issue 31", "[issues.31]") {
 TEST_CASE("Issue 33", "[issues.33]") {
     tl::expected<void, int> res {tl::unexpect, 0};
     REQUIRE(!res);    
-    res = res.map_error([](int i) { return 42; });
+    res = res.map_error([](int i) { (void)i; return 42; });
     REQUIRE(res.error() == 42);
 }
 


### PR DESCRIPTION
Fixes the following warnings in test code:
-Wmacro-redefined
-Wreturn-type
-Wunused-parameter
-Wunused-value
-Wunused-variable

Tabs converted to spaces in the expected header.