### PR TITLE
Mention being tested on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The interface is the same as `std::expected` as proposed in [p0323r3](http://www
 
 Tested on:
 
+- OpenBSD
+  * clang 13.0.0
+  * clang 11.1.0
+  * g++ 8.4.0
 - Linux
   * clang 6.0.1
   * clang 5.0.2


### PR DESCRIPTION
Release 1.0.0 has been ported to OpenBSD, used in other ports such as
net/tdeskop (official Telegram Desktop client) and the official tests
report "All tests passed (377 assertions in 26 test cases)" on
OpenBSD 7.0 -CURRENT using three different compilers.
