### PR TITLE
Fix `-Wreturn-type` and `-Wunused-parameter` warnings in tests. NFC.

### DIFF
--- a/tests/bases.cpp
+++ b/tests/bases.cpp
@@ -37,11 +37,11 @@ TEST_CASE("Triviality", "[bases.triviality]") {
 
     {
         struct T {
-            T(const T&){}
-            T(T&&) {};
-            T& operator=(const T&) {}
-            T& operator=(T&&) {};
-            ~T(){}
+            T(const T&) {}
+            T(T&&) {}
+            T& operator=(const T&) { return *this; }
+            T& operator=(T&&) { return *this; }
+            ~T() {}
         };
         REQUIRE(!std::is_trivially_copy_constructible<tl::expected<T,int>>::value);
         REQUIRE(!std::is_trivially_copy_assignable<tl::expected<T,int>>::value);

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE("Map extensions", "[extensions.map]") {
   auto mul2 = [](int a) { return a * 2; };
-  auto ret_void = [](int a) {};
+  auto ret_void = [](int) {};
 
   {
     tl::expected<int, int> e = 21;
@@ -143,7 +143,7 @@ TEST_CASE("Map extensions", "[extensions.map]") {
 
 TEST_CASE("Map error extensions", "[extensions.map_error]") {
   auto mul2 = [](int a) { return a * 2; };
-  auto ret_void = [](int a) {};
+  auto ret_void = [](int) {};
 
   {
     tl::expected<int, int> e = 21;
@@ -252,8 +252,8 @@ TEST_CASE("Map error extensions", "[extensions.map_error]") {
 }
 
 TEST_CASE("And then extensions", "[extensions.and_then]") {
-  auto succeed = [](int a) { return tl::expected<int, int>(21 * 2); };
-  auto fail = [](int a) { return tl::expected<int, int>(tl::unexpect, 17); };
+  auto succeed = [](int) { return tl::expected<int, int>(21 * 2); };
+  auto fail = [](int) { return tl::expected<int, int>(tl::unexpect, 17); };
 
   {
     tl::expected<int, int> e = 21;
@@ -370,9 +370,9 @@ TEST_CASE("And then extensions", "[extensions.and_then]") {
 
 TEST_CASE("or_else", "[extensions.or_else]") {
   using eptr = std::unique_ptr<int>;
-  auto succeed = [](int a) { return tl::expected<int, int>(21 * 2); };
-  auto succeedptr = [](eptr e) { return tl::expected<int,eptr>(21*2);};
-  auto fail =    [](int a) { return tl::expected<int,int>(tl::unexpect, 17);};
+  auto succeed = [](int) { return tl::expected<int, int>(21 * 2); };
+  auto succeedptr = [](eptr) { return tl::expected<int,eptr>(21*2);};
+  auto fail =    [](int) { return tl::expected<int,int>(tl::unexpect, 17);};
   auto efail =   [](eptr e) { *e = 17;return tl::expected<int,eptr>(tl::unexpect, std::move(e));};
   auto failptr = [](eptr e) { return tl::expected<int,eptr>(tl::unexpect, std::move(e));};
   auto failvoid = [](int) {};
@@ -568,9 +568,7 @@ struct F {
 TEST_CASE("14", "[issue.14]") {
     auto res = tl::expected<S,F>{tl::unexpect, F{}};
 
-    res.map_error([](F f) {
-
-    });
+    res.map_error([](F) {});
 }
 
 TEST_CASE("32", "[issue.32]") {

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Issue 1", "[issues.1]") { getInt1(); }
 
 tl::expected<int, int> operation1() { return 42; }
 
-tl::expected<std::string, int> operation2(int const val) { return "Bananas"; }
+tl::expected<std::string, int> operation2(int) { return "Bananas"; }
 
 TEST_CASE("Issue 17", "[issues.17]") {
   auto const intermediate_result = operation1();
@@ -77,7 +77,7 @@ TEST_CASE("Issue 31", "[issues.31]") {
 TEST_CASE("Issue 33", "[issues.33]") {
     tl::expected<void, int> res {tl::unexpect, 0};
     REQUIRE(!res);    
-    res = res.map_error([](int i) { return 42; });
+    res = res.map_error([](int) { return 42; });
     REQUIRE(res.error() == 42);
 }
 


### PR DESCRIPTION
Note that `or_else::[extensions.or_else]` still has an unused variable:

    auto failptr = [](eptr e) { return tl::expected<int,eptr>(tl::unexpect, std::move(e));};

but I didn't remove it because it looks like it probably indicates some missing test coverage.