### PR TITLE
Add deduction guide to tl::unexpected

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -147,6 +147,11 @@ private:
   E m_val;
 };
 
+#ifdef __cpp_deduction_guides
+template<class E>
+unexpected(E) -> unexpected<E>;
+#endif
+
 template <class E>
 constexpr bool operator==(const unexpected<E> &lhs, const unexpected<E> &rhs) {
   return lhs.value() == rhs.value();


### PR DESCRIPTION
Adds CTAD deduction guide (if supported as indicated by feature test macro: `__cpp_deduction_guides`) to `tl::unexpected` for easier syntax on returns