### PR TITLE
Update Catch2 version to fix compilation error with glibc greater than 2.33

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(EXPECTED_BUILD_TESTS)
   set(CATCH_BUILD_TESTING OFF)
   set(CATCH_INSTALL_DOCS OFF)
   FetchContent_Declare(Catch2 URL
-    https://github.com/catchorg/Catch2/archive/v2.9.2.zip) 
+    https://github.com/catchorg/Catch2/archive/v2.13.5.zip)
   FetchContent_MakeAvailable(Catch2)
 
   file(GLOB test-sources CONFIGURE_DEPENDS tests/*.cpp)


### PR DESCRIPTION
Bump Catch2 version from v2.9.2 to v2.13.5 to fix `MINSIGSTKSZ` not being used as a constant expression (see #114).