### PR TITLE
Update Catch2 to version 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(EXPECTED_BUILD_TESTS)
   set(CATCH_BUILD_TESTING OFF)
   set(CATCH_INSTALL_DOCS OFF)
   FetchContent_Declare(Catch2 URL
-    https://github.com/catchorg/Catch2/archive/v2.9.2.zip) 
+    https://github.com/catchorg/Catch2/archive/v3.1.0.zip)
   FetchContent_MakeAvailable(Catch2)
 
   file(GLOB test-sources CONFIGURE_DEPENDS tests/*.cpp)
@@ -79,7 +79,7 @@ if(EXPECTED_BUILD_TESTS)
 
   target_link_libraries(${PROJECT_NAME}-tests
     PRIVATE
-      Catch2::Catch2
+      Catch2::Catch2WithMain
       expected)
   add_test(NAME tl::expected::tests COMMAND ${PROJECT_NAME}-tests)
 endif()

--- a/tests/assignment.cpp
+++ b/tests/assignment.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 TEST_CASE("Simple assignment", "[assignment.simple]") {

--- a/tests/bases.cpp
+++ b/tests/bases.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 #include <string>

--- a/tests/constexpr.cpp
+++ b/tests/constexpr.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 TEST_CASE("Constexpr", "[constexpr]") {

--- a/tests/constructors.cpp
+++ b/tests/constructors.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 #include <type_traits>

--- a/tests/emplace.cpp
+++ b/tests/emplace.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 #include <memory>
 #include <vector>

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 #define TOKENPASTE(x, y) x##y

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 #include <string>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>

--- a/tests/noexcept.cpp
+++ b/tests/noexcept.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 TEST_CASE("Noexcept", "[noexcept]") {

--- a/tests/observers.cpp
+++ b/tests/observers.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 struct move_detector {

--- a/tests/relops.cpp
+++ b/tests/relops.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 TEST_CASE("Relational operators", "[relops]") {

--- a/tests/swap.cpp
+++ b/tests/swap.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/expected.hpp>
 
 struct no_throw {


### PR DESCRIPTION
Update to the latest version solves the problem with error related to stack size.

  In file included from /usr/include/signal.h:328,
                   from /symforce/third_party/catch2/include/catch.hpp:8152,
                   from /symforce/third_party/catch2/src/catch_amalgamated.cpp:15:
  /symforce/third_party/catch2/src/catch_amalgamated.cpp:3580:54: error: call to non-'constexpr' function 'long int sysconf(int)'
   3580 | static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
        |                                                      ^~~~~~~~~~~
  In file included from /usr/include/x86_64-linux-gnu/bits/sigstksz.h:24,
                   from /usr/include/signal.h:328,
                   from /symforce/third_party/catch2/include/catch.hpp:8152,
                   from /symforce/third_party/catch2/src/catch_amalgamated.cpp:15:
  /usr/include/unistd.h:640:17: note: 'long int sysconf(int)' declared here
    640 | extern long int sysconf (int __name) __THROW;
        |                 ^~~~~~~
  /symforce/third_party/catch2/src/catch_amalgamated.cpp:3633:41: error: size of array 'altStackMem' is not an integral constant-expression
   3633 | char FatalConditionHandler::altStackMem[sigStackSize] = {};