### PR TITLE
Fixed issue #129.

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -199,13 +199,14 @@ static constexpr unexpect_t unexpect{};
 
 namespace detail {
 template <typename E>
-[[noreturn]] TL_EXPECTED_11_CONSTEXPR void throw_exception([[maybe_unused]] E &&e) {
+[[noreturn]] TL_EXPECTED_11_CONSTEXPR void throw_exception(E &&e) {
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
   throw std::forward<E>(e);
 #else
 #ifdef _MSC_VER
   __assume(0);
 #else
+  (void)e;
   __builtin_unreachable();
 #endif
 #endif

--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -199,7 +199,7 @@ static constexpr unexpect_t unexpect{};
 
 namespace detail {
 template <typename E>
-[[noreturn]] TL_EXPECTED_11_CONSTEXPR void throw_exception(E &&e) {
+[[noreturn]] TL_EXPECTED_11_CONSTEXPR void throw_exception([[maybe_unused]] E &&e) {
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
   throw std::forward<E>(e);
 #else
@@ -819,7 +819,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
       geterr().~unexpected<E>();
       construct(std::move(rhs).get());
     } else {
-      assign_common(rhs);
+      assign_common(std::move(rhs));
     }
   }
 

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -184,3 +184,11 @@ TEST_CASE("Issue 107", "[issues.107]") {
     REQUIRE(ex2.error().i == 2);
     REQUIRE(ex2.error().j == 2);
 }
+
+TEST_CASE("Issue 129", "[issues.129]") {
+  tl::expected<std::unique_ptr<int>, int> x1 {std::make_unique<int>(4)};
+  tl::expected<std::unique_ptr<int>, int> y1 {std::make_unique<int>(2)};
+  x1 = std::move(y1);
+
+  REQUIRE(**x1 == 2);
+}

--- a/tests/swap.cpp
+++ b/tests/swap.cpp
@@ -13,6 +13,7 @@ struct canthrow_move {
   std::string i;
 };
 
+#ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
 bool should_throw = false;
 struct willthrow_move {
   willthrow_move(std::string i) : i(i) {}
@@ -24,6 +25,8 @@ struct willthrow_move {
   willthrow_move &operator=(willthrow_move &&) = default;
   std::string i;
 };
+#endif // TL_EXPECTED_EXCEPTIONS_ENABLED
+
 static_assert(tl::detail::is_swappable<no_throw>::value, "");
 
 template <class T1, class T2> void swap_test() {
@@ -79,6 +82,7 @@ template <class T1, class T2> void swap_test() {
   REQUIRE(b.error().i == s1);
 }
 
+#ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
 TEST_CASE("swap") {
 
   swap_test<no_throw, no_throw>();
@@ -99,3 +103,4 @@ TEST_CASE("swap") {
   REQUIRE(a->i == s1);
   REQUIRE(b.error().i == s2);
 }
+#endif // TL_EXPECTED_EXCEPTIONS_ENABLED


### PR DESCRIPTION
+ Added a `[maybe_unused]` attribute to get rid of an unused parameter warning
+ `std::move`ing the parameter into `assign_common()` in the rvalue reference overload of `assign()`
+ Added a compile guard to `swap.cpp` to allow compilation with `-fno-exceptions`