### PR TITLE
Fixed issue #129

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -203,6 +203,7 @@ template <typename E>
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
   throw std::forward<E>(e);
 #else
+  (void)e;
 #ifdef _MSC_VER
   __assume(0);
 #else
@@ -819,7 +820,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
       geterr().~unexpected<E>();
       construct(std::move(rhs).get());
     } else {
-      assign_common(rhs);
+      assign_common(std::move(rhs));
     }
   }
 

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -184,3 +184,11 @@ TEST_CASE("Issue 107", "[issues.107]") {
     REQUIRE(ex2.error().i == 2);
     REQUIRE(ex2.error().j == 2);
 }
+
+TEST_CASE("Issue 129", "[issues.129]") {
+  tl::expected<std::unique_ptr<int>, int> x1 {std::make_unique<int>(4)};
+  tl::expected<std::unique_ptr<int>, int> y1 {std::make_unique<int>(2)};
+  x1 = std::move(y1);
+
+  REQUIRE(**x1 == 2);
+}

--- a/tests/swap.cpp
+++ b/tests/swap.cpp
@@ -14,6 +14,8 @@ struct canthrow_move {
 };
 
 bool should_throw = false;
+
+#ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
 struct willthrow_move {
   willthrow_move(std::string i) : i(i) {}
   willthrow_move(willthrow_move const &) = default;
@@ -24,6 +26,8 @@ struct willthrow_move {
   willthrow_move &operator=(willthrow_move &&) = default;
   std::string i;
 };
+#endif // TL_EXPECTED_EXCEPTIONS_ENABLED
+
 static_assert(tl::detail::is_swappable<no_throw>::value, "");
 
 template <class T1, class T2> void swap_test() {
@@ -79,6 +83,7 @@ template <class T1, class T2> void swap_test() {
   REQUIRE(b.error().i == s1);
 }
 
+#ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
 TEST_CASE("swap") {
 
   swap_test<no_throw, no_throw>();
@@ -99,3 +104,4 @@ TEST_CASE("swap") {
   REQUIRE(a->i == s1);
   REQUIRE(b.error().i == s2);
 }
+#endif // TL_EXPECTED_EXCEPTIONS_ENABLED


### PR DESCRIPTION
+ Fixed unused variable warning
+ Added a `std::move` to avoid calling copy-assignment operator on non-copyable types