### PR TITLE
Add CMake artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 \#*
 .\#*
 /build/
+
+# CMake
+CMakeFiles/
+CTestTestfile.cmake
+cmake_install.cmake
+tl-expected-config-version.cmake
+tl-expected-config.cmake
+
+Makefile


### PR DESCRIPTION
Otherwise they cause noise when this library is used as a git submodule and a CMake subdirectory in a project like this:

  Changes not staged for commit:
    (use "git add <file>..." to update what will be committed)
    (use "git restore <file>..." to discard changes in working directory)
    (commit or discard the untracked or modified content in submodules)
	  modified:   vendor/expected (untracked content)

Running `cmake .` in such a project creates CMake artifacts and then `git status` reports them "untracked content".