### PR TITLE
Fix bug if TL_EXPECTED_EXCEPTIONS_ENABLED were disabled

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -1707,7 +1707,9 @@ public:
     if (has_value()) {
       val() = std::forward<U>(v);
     } else {
+#ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
       auto tmp = std::move(err());
+#endif
       err().~unexpected<E>();
 
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
@@ -1776,7 +1778,9 @@ public:
       val().~T();
       ::new (valptr()) T(std::forward<Args>(args)...);
     } else {
+#ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
       auto tmp = std::move(err());
+#endif
       err().~unexpected<E>();
 
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED


### PR DESCRIPTION
Found a bug where when using `expected &operator=()` while providing an expected value and not allowing exceptions to be used `TL_EXPECTED_EXCEPTIONS_ENABLED = false` then a variable `tmp` is set but unused which causes errors in C++ compilation.