### PR TITLE
ci: Update to `actions/checkout@v4` from `v3`.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -108,7 +108,7 @@ jobs:
             install: sudo apt install clang-11
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Setup Toolchain
       run: |


### PR DESCRIPTION
This is an update to the more recent NodeJS toolchain within GitHub Actions.