### PR TITLE
Fix bug in unequal operator with void as expected value

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -2392,7 +2392,7 @@ constexpr bool operator!=(const expected<void, E> &lhs,
                           const expected<void, F> &rhs) {
   return (lhs.has_value() != rhs.has_value())
              ? true
-             : (!lhs.has_value() ? lhs.error() == rhs.error() : false);
+             : (!lhs.has_value() ? lhs.error() != rhs.error() : false);
 }
 
 template <class T, class E, class U>


### PR DESCRIPTION
- Fix unequal operator (!=) for comparing two tl::expected values with void as expected value.