### PR TITLE
Fix constructor overload resolution for derived classes

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -398,8 +398,8 @@ template <class T, class E, class U>
 using expected_enable_forward_value = detail::enable_if_t<
     std::is_constructible<T, U &&>::value &&
     !std::is_same<detail::decay_t<U>, in_place_t>::value &&
-    !std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
-    !std::is_same<unexpected<E>, detail::decay_t<U>>::value>;
+    !std::is_base_of<expected<T, E>, detail::decay_t<U>>::value &&
+    !std::is_base_of<unexpected<E>, detail::decay_t<U>>::value>;
 
 template <class T, class E, class U, class G, class UR, class GR>
 using expected_enable_from_other = detail::enable_if_t<

--- a/tests/derived.cpp
+++ b/tests/derived.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch.hpp>
+#include <tl/expected.hpp>
+
+namespace tl {
+    template <typename T, typename E>
+    class derived : public tl::expected<T,E>
+    {
+    public:
+        derived() : tl::expected<T,E>() {}
+        template <typename G>
+        derived(unexpected<G> const &e) : tl::expected<T,E>(e) {}
+        derived(const derived& d) : tl::expected<T,E>(d) {}
+        derived(derived&& d) : tl::expected<T,E>(std::move(d)) {}
+        // TODO: Add overloads for other constructors
+    };
+}
+
+TEST_CASE("Derived constructors", "[constructors.derived]") {
+    {
+        tl::derived<int,int> e;
+        REQUIRE(e);
+        REQUIRE(e == 0);
+    }
+
+    // Construct from unexpected
+    {
+        tl::derived<int,int> e = tl::make_unexpected(0);
+        REQUIRE(!e);
+        REQUIRE(e.error() == 0);
+    }
+
+    // Copy construct
+    {
+        tl::derived<bool, int> e;
+        REQUIRE(e);
+        REQUIRE(!e.value());
+
+        tl::derived<bool, int> e_copy(e);
+        REQUIRE(e_copy);
+        REQUIRE(e_copy.value() == e.value());
+    }
+
+    // Move construct
+    {
+        tl::derived<bool, int> e;
+        REQUIRE(e);
+        REQUIRE(e == false);
+
+        tl::derived<bool, int> e_move(std::move(e));
+        REQUIRE(e_move);
+        REQUIRE(!e_move.value());
+    }
+}


### PR DESCRIPTION
Proposed fix for https://github.com/TartanLlama/expected/issues/157

Removes general templated constructor overloads from candidate list if constructor arguments are of type `tl::expected` or classes derived from it.