### PR TITLE
Add [[nodiscard]] to tl::expected

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -133,7 +133,7 @@ struct is_trivially_copy_constructible<std::vector<T, A>> : std::false_type {};
 #endif
 
 namespace tl {
-template <class T, class E> class expected;
+template <class T, class E> class [[nodiscard]] expected;
 
 #ifndef TL_MONOSTATE_INPLACE_MUTEX
 #define TL_MONOSTATE_INPLACE_MUTEX
@@ -1276,7 +1276,8 @@ private:
 /// has been destroyed. The initialization state of the contained object is
 /// tracked by the expected object.
 template <class T, class E>
-class expected : private detail::expected_move_assign_base<T, E>,
+class [[nodiscard]] expected :
+                 private detail::expected_move_assign_base<T, E>,
                  private detail::expected_delete_ctor_base<T, E>,
                  private detail::expected_delete_assign_base<T, E>,
                  private detail::expected_default_ctor_base<T, E> {

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -814,7 +814,7 @@ struct F {
 TEST_CASE("14", "[issue.14]") {
     auto res = tl::expected<S,F>{tl::unexpect, F{}};
 
-    res.map_error([](F f) {
+    (void)res.map_error([](F f) {
         (void)f;
     });
 }
@@ -822,7 +822,7 @@ TEST_CASE("14", "[issue.14]") {
 TEST_CASE("32", "[issue.32]") {
     int i = 0;
     tl::expected<void, int> a;
-    a.map([&i]{i = 42;});
+    (void)a.map([&i]{i = 42;});
     REQUIRE(i == 42);
 
     auto x = a.map([]{return 42;});

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -13,7 +13,7 @@ tl::expected<int, string> getInt2(int val) { return val; }
 
 tl::expected<int, string> getInt1() { return getInt2(5).and_then(getInt3); }
 
-TEST_CASE("Issue 1", "[issues.1]") { getInt1(); }
+TEST_CASE("Issue 1", "[issues.1]") { (void)getInt1(); }
 
 tl::expected<int, int> operation1() { return 42; }
 
@@ -22,7 +22,7 @@ tl::expected<std::string, int> operation2(int const val) { (void)val; return "Ba
 TEST_CASE("Issue 17", "[issues.17]") {
   auto const intermediate_result = operation1();
 
-  intermediate_result.and_then(operation2);
+  (void)intermediate_result.and_then(operation2);
 }
 
 struct a {};
@@ -61,7 +61,7 @@ tl::expected<int, std::string> error() {
 std::string maperror(std::string s) { return s + "maperror "; }
 
 TEST_CASE("Issue 30", "[issues.30]") {
-  error().map_error(maperror);
+  (void)error().map_error(maperror);
 }
 
 struct i31{
@@ -91,7 +91,7 @@ void errorhandling(std::string){}
 TEST_CASE("Issue 34", "[issues.34]") {
   tl::expected <int, std::string> result = voidWork ()
       .and_then (work2);
-  result.map_error ([&] (std::string result) {errorhandling (result);});
+  (void)result.map_error ([&] (std::string result) {errorhandling (result);});
 }
 
 struct non_copyable {
@@ -101,7 +101,7 @@ struct non_copyable {
 };
 
 TEST_CASE("Issue 42", "[issues.42]") {
-	tl::expected<non_copyable,int>{}.map([](non_copyable) {});
+ 	(void)tl::expected<non_copyable,int>{}.map([](non_copyable) {});
 }
 
 TEST_CASE("Issue 43", "[issues.43]") {

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -144,12 +144,12 @@ struct move_tracker {
 
         move_tracker() = default;
 
-        move_tracker(move_tracker const &other) noexcept {};
+        move_tracker(move_tracker const &other) noexcept;
         move_tracker(move_tracker &&orig) noexcept
             : moved(orig.moved + 1) {}
 
         move_tracker &
-        operator=(move_tracker const &other) noexcept {};
+        operator=(move_tracker const &other) noexcept;
         
         move_tracker &operator=(move_tracker &&orig) noexcept {
           moved = orig.moved + 1;


### PR DESCRIPTION
Microsoft STL added [[nodiscard]] on 2024-12-13; see https://github.com/microsoft/STL/pull/5174

martinmoene/expected-lite added [[nodiscard]] on 2024-12-10; see https://github.com/martinmoene/expected-lite/pull/74

See https://quuxplusone.github.io/blog/2024/12/08/should-expected-be-nodiscard/ for further rationale, if needed.