### PR TITLE
Make tl namespace configurable

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -25,6 +25,10 @@
 #include <type_traits>
 #include <utility>
 
+#ifndef TL_EXPECTED_NAMESPACE
+#define TL_EXPECTED_NAMESPACE tl
+#endif
+
 #if defined(__EXCEPTIONS) || defined(_CPPUNWIND)
 #define TL_EXPECTED_EXCEPTIONS_ENABLED
 #endif
@@ -81,7 +85,7 @@
 #elif (defined(__GNUC__) && __GNUC__ < 8 && !defined(__clang__))
 #ifndef TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
 #define TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
-namespace tl {
+namespace TL_EXPECTED_NAMESPACE {
 namespace detail {
 template <class T>
 struct is_trivially_copy_constructible
@@ -91,11 +95,11 @@ template <class T, class A>
 struct is_trivially_copy_constructible<std::vector<T, A>> : std::false_type {};
 #endif
 } // namespace detail
-} // namespace tl
+} // namespace TL_EXPECTED_NAMESPACE
 #endif
 
 #define TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)                         \
-  tl::detail::is_trivially_copy_constructible<T>
+  TL_EXPECTED_NAMESPACE::detail::is_trivially_copy_constructible<T>
 #define TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T)                            \
   std::is_trivially_copy_assignable<T>
 #define TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)                               \
@@ -132,7 +136,7 @@ struct is_trivially_copy_constructible<std::vector<T, A>> : std::false_type {};
 #define TL_EXPECTED_11_CONSTEXPR constexpr
 #endif
 
-namespace tl {
+namespace TL_EXPECTED_NAMESPACE {
 template <class T, class E> class expected;
 
 #ifndef TL_MONOSTATE_INPLACE_MUTEX
@@ -394,7 +398,7 @@ struct is_nothrow_swappable
 #endif
 #endif
 
-// Trait for checking if a type is a tl::expected
+// Trait for checking if a type is a TL_EXPECTED_NAMESPACE::expected
 template <class T> struct is_expected_impl : std::false_type {};
 template <class T, class E>
 struct is_expected_impl<expected<T, E>> : std::true_type {};
@@ -2471,6 +2475,6 @@ void swap(expected<T, E> &lhs,
           expected<T, E> &rhs) noexcept(noexcept(lhs.swap(rhs))) {
   lhs.swap(rhs);
 }
-} // namespace tl
+} // namespace TL_EXPECTED_NAMESPACE
 
 #endif


### PR DESCRIPTION
This can make it easier to use tl::expected in Qt