### PR TITLE
Copyright: add SPDX licence identifier

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -1,6 +1,6 @@
 ///
 // expected - An implementation of std::expected with extensions
-// Written in 2017 by Sy Brand (tartanllama@gmail.com, @TartanLlama)
+// Copyright (C) 2017 Sy Brand (tartanllama@gmail.com, @TartanLlama)
 //
 // Documentation available at http://tl.tartanllama.xyz/
 //
@@ -11,6 +11,8 @@
 // You should have received a copy of the CC0 Public Domain Dedication
 // along with this software. If not, see
 // <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+// SPDX-License-Identifier: CC0-1.0
 ///
 
 #ifndef TL_EXPECTED_HPP


### PR DESCRIPTION
* added SPDX-License-Identifier tag
* convert "Written in" to "Copyright (C)"

Trying to integrate lt::expected into Qt, the license checker was expecting these two changes to make the license checker happy.

--

broken out of https://codereview.qt-project.org/c/qt/qtbase/+/589289