### PR TITLE
TL_CPLUSPLUS is being used before being defined

### DIFF
--- a/include/tl/expected.hpp
+++ b/include/tl/expected.hpp
@@ -51,6 +51,12 @@
 #define TL_EXPECTED_GCC55
 #endif
 
+#ifdef _MSVC_LANG
+#define TL_CPLUSPLUS _MSVC_LANG
+#else
+#define TL_CPLUSPLUS __cplusplus
+#endif
+
 #if !defined(TL_ASSERT)
 //can't have assert in constexpr in C++11 and GCC 4.9 has a compiler bug
 #if (TL_CPLUSPLUS > 201103L) && !defined(TL_EXPECTED_GCC49)
@@ -107,12 +113,6 @@ struct is_trivially_copy_constructible<std::vector<T, A>> : std::false_type {};
   std::is_trivially_copy_assignable<T>
 #define TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)                               \
   std::is_trivially_destructible<T>
-#endif
-
-#ifdef _MSVC_LANG
-#define TL_CPLUSPLUS _MSVC_LANG
-#else
-#define TL_CPLUSPLUS __cplusplus
 #endif
 
 #if TL_CPLUSPLUS > 201103L


### PR DESCRIPTION
For most of us, `TL_ASSERT` will be undefined when we include `tl/expected.hpp`.  If it is not defined, there is another check to see if `TL_CPLUSPLUS > 201103L`, but `TL_CPLUSPLUS` has not yet been defined either.

Depending on your compiler switches, either this is a warning, an error, or nothing.  If not a compiler error, `TL_CPLUSPLUS` will be `0`, which is less than `201103L`, which means `TL_ASSERT` will do nothing.

So, either you get a compiler error, or you get no asserts.

Here is the error I get when I don't treat it as a system header:

```
error: 'TL_CPLUSPLUS' is not defined, evaluates to 0 [-Werror,-Wundef]
```